### PR TITLE
Switch deployment to GitHub pages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,57 @@
+# This workflow builds and uploads the page to the GitHub page associated with
+# this repository
+name: Build and deploy to Github pages
+# ADAPTED FROM https://github.com/actions/starter-workflows/blob/main/pages/static.yml
+
+on:
+  # Runs on pushes targeting the default branch (in our case: main)
+  push:
+    branches: [$default-branch]
+  # This toggle enables us to run the workflow manually
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Only one build at a time (cancel running ones if necessary)
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout the repo
+      - name: Checkout
+        uses: actions/checkout@v3
+
+
+      # --- --- --- FROM HERE ON BUILDING
+      - name: Setup NodeJS 16
+        uses: actions/setup-node@v1
+        with:
+          node-version: '16'
+      - name: Run build script
+      # NOTE: We have to switch this out for the real build script once we have it
+        run: |
+          ./scripts/build.sh
+
+
+      # From here on only upload and deploy
+      - name: Setup Pages
+        uses: actions/configure-pages@v2
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          # Upload the "dist" directory
+          path: './dist'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
-#Mac system files
+# Mac system files
 .DS_Store
+
+# Build directory
+dist

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "mastodon-lists",
+  "version": "1.0.0",
+  "description": "A template to build hand-curated lists of accounts to follow",
+  "main": "index.js",
+  "repository": "https://github.com/trutzig89182/Mastodon-Sociologists.git",
+  "author": "Hendrik Erz <hendrik@zettlr.com>",
+  "license": "GPL-3.0",
+  "scripts": {
+    "build": "node scripts/build.js"
+  }
+}

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,0 +1,2 @@
+// DEBUG: DUMMY SCRIPT! We need this (respectively webpack) once we switch to
+// a dynamic page build.

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,11 @@
+echo "Running in directory $(pwd)"
+echo "$(ls)"
+mkdir dist
+cp index.html ./dist
+cp tootformat.html ./dist
+cp instructions.html ./dist
+cp instructions.pdf ./dist
+
+# Copy the dirs
+cp -R ./resources ./dist/
+cp -R ./assets ./dist/


### PR DESCRIPTION
This PR introduces a GitHub Pages workflow. This workflow enables us to have fine-grained control over the build process and is the first step towards a much easier customizable template for such lists that other people can use.

For now, all that this thing does is copy the required files over to a deployment directory `dist` from which out it will then be deployed via GitHub actions.

## Necessary additional setup

On the repository, you need to switch the Github pages generation to the Github pages actions setting:

<img width="1163" alt="image" src="https://user-images.githubusercontent.com/17251683/200075316-bbaa4f1c-8e28-4189-abbb-dada59aca2ac.png">

The workflow is set up so that – as soon as it's in main – it builds on every push to main (not develop --> enables us to work on the develop branch). However, it can also be triggered manually.

In order to do so, head over to the "Actions" tab of the repository, click on the workflow name, and then next to the message "This workflow has a trigger" click on "Run workflow":

<img width="1680" alt="image" src="https://user-images.githubusercontent.com/17251683/200075507-ecdc1b1c-4c06-407b-b008-a56fddd20c82.png">
