### PR TITLE
Patch: support empty "link" field in CSV

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -159,7 +159,9 @@ function buildUserSelectionForm (users) {
      nameAsLink.setAttribute('target', 'blank')
      wrapper.appendChild(nameAsLink)
    } else {
+     const nameWithoutLink = document.createTextNode(user.name)
      wrapper.appendChild(nameWithoutLink)
+     console.error('Profile URL for ' + user.name + ' is missing.')
    }
    wrapper.appendChild(bracketClose)
 


### PR DESCRIPTION
Handling an empty profile url was not yet impelemented. I quick fixed this, because a problem occured.
If the "link" field of an account is empty, now the name will be rendered without being a link. An error message is thrown, that this user does not have a "link".